### PR TITLE
B2BM-38 - add different error messages serial number

### DIFF
--- a/src/main/java/com/shs/b2bm/claim/service/services/impl/ValidationSerialNumberServiceImpl.java
+++ b/src/main/java/com/shs/b2bm/claim/service/services/impl/ValidationSerialNumberServiceImpl.java
@@ -29,19 +29,31 @@ public class ValidationSerialNumberServiceImpl extends ValidationStrategyService
   public ValidationResult executeValidation(
       ServiceOrder serviceOrder, ValidationResult validationResult, JsonNode rulesDetails) {
 
-    int serialNumberLength =
+    String serialNumber =
         (serviceOrder.getMerchandise() != null
                 && serviceOrder.getMerchandise().getSerialNumber() != null)
-            ? serviceOrder.getMerchandise().getSerialNumber().length()
-            : 0;
+            ? serviceOrder.getMerchandise().getSerialNumber()
+            : "";
 
     boolean isRequired = extractValueFromJson.getBoolean(rulesDetails, "required", true);
     int minLength = extractValueFromJson.getInt(rulesDetails, "minLength", 0);
     int maxLength = extractValueFromJson.getInt(rulesDetails, "maxLength", Integer.MAX_VALUE);
 
-    if ((isRequired && serviceOrder.getMerchandise().getSerialNumber().isBlank())
-        || serialNumberLength < minLength
-        || serialNumberLength > maxLength) {
+    if (isRequired && serialNumber.isBlank()) {
+      String errorMessageRequired =
+          extractValueFromJson.getString(
+              rulesDetails, "errorMessageRequired", "Serial missing");
+      validationResult.setErrorMessage(
+          validationResult.getErrorMessage().concat(" ").concat(errorMessageRequired));
+      validationResult.setStatus(StatusValidation.Error);
+    }
+
+    if (serialNumber.length() < minLength || serialNumber.length() > maxLength) {
+      String errorMessageLength =
+          extractValueFromJson.getString(
+              rulesDetails, "errorMessageLength", "Serial too short");
+      validationResult.setErrorMessage(
+          validationResult.getErrorMessage().concat(" ").concat(errorMessageLength));
       validationResult.setStatus(StatusValidation.Error);
     }
 

--- a/src/main/resources/db/migration/V1__Initial_Schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_Schema.sql
@@ -60,9 +60,9 @@ CREATE TABLE validation_config  (
 
 INSERT INTO validation_config(rule_name, obligor_id, rule_details, error_message, created_date, last_modified_date, created_by, last_modified_by)
 VALUES
-('SerialNumberValidation', 1, '{"required" : "true", "minLength" : "0", "maxLength": "10"}', 'Serial Number does not meet the required parameters', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
-('SerialNumberValidation', 2, '{"required" : "true", "minLength" : "5", "maxLength": "15"}', 'Serial Number does not meet the required parameters', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
-('SerialNumberValidation', 3, '{"required" : "false", "minLength" : "0", "maxLength": "50"}', 'Serial Number does not meet the required parameters', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
+('SerialNumberValidation', 1, '{"required" : "true", "errorMessageRequired": "Serial missing", "minLength" : "0", "maxLength": "10", "errorMessageLength": "Serial too short"}', 'Serial Number does not meet the required parameters', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
+('SerialNumberValidation', 2, '{"required" : "true", "errorMessageRequired": "Serial missing", "minLength" : "5", "maxLength": "15", "errorMessageLength": "Serial too short"}', 'Serial Number does not meet the required parameters', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
+('SerialNumberValidation', 3, '{"required" : "false", "errorMessageRequired": "Serial missing", "minLength" : "0", "maxLength": "50", "errorMessageLength": "Serial too short"}', 'Serial Number does not meet the required parameters', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
 ('ApprovedBrand', 1, '{"listApprovedBrand" : ["LG", "Samsung"]}', 'Unrecognized brand for obligor', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
 ('ApprovedBrand', 2, '{"listApprovedBrand" : ["LG", "Samsung"]}', 'Unrecognized brand for obligor', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),
 ('ApprovedBrand', 3, '{"listApprovedBrand" : ["LG", "Samsung"]}', 'Unrecognized brand for obligor', '2025-05-29', '2025-05-29', 'b2bm-claim-service', 'b2bm-claim-service'),


### PR DESCRIPTION
This pull request introduces enhancements to the serial number validation logic in the `ValidationSerialNumberServiceImpl` class and updates the database schema to support more detailed error messaging. The changes improve the clarity and specificity of validation error messages while maintaining backward compatibility.

### Enhancements to serial number validation logic:
* Refactored the `executeValidation` method in `ValidationSerialNumberServiceImpl` to handle serial number validation in two distinct steps: checking for required presence and validating length constraints. Each validation step now sets a specific error message if the condition fails. (`src/main/java/com/shs/b2bm/claim/service/services/impl/ValidationSerialNumberServiceImpl.java`, [src/main/java/com/shs/b2bm/claim/service/services/impl/ValidationSerialNumberServiceImpl.javaL32-R56](diffhunk://#diff-80b5de974856b7a1bae2806d370f5c4b073fba7df911bdc0576f86fe0f3cd260L32-R56))

### Database schema updates:
* Updated the `validation_config` table to include new JSON fields (`errorMessageRequired` and `errorMessageLength`) for specifying custom error messages for missing or invalid serial numbers. These changes provide more granular control over error reporting. (`src/main/resources/db/migration/V1__Initial_Schema.sql`, [src/main/resources/db/migration/V1__Initial_Schema.sqlL63-R65](diffhunk://#diff-d302b3c5bc6dd340dc7b1e49a52b07e1db51a35b0c96ea21b520b17a0f61545dL63-R65))